### PR TITLE
fix(readmes): remove cni references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Overview
 
-This is a coding exercise to help us assess candidates looking to join the team at Condé Nast International.  The test is intended to be completed at home and we expect you to spend no more than half a day working on it. We appreciate the time you spend on it and we will go through your submitted work together when you're invited to meet us face-to-face.        
+This is a coding exercise to help us assess candidates looking to join the team at Condé Nast.  The test is intended to be completed at home and we expect you to spend no more than half a day working on it. We appreciate the time you spend on it and we will go through your submitted work together when you're invited to meet us face-to-face.        
 
 ## Which test shall I pick?
  - [Software Engineer](se-test)

--- a/infra-test/README.md
+++ b/infra-test/README.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-This is a coding exercise to help us assess candidates looking to join the Infrastructure Engineering team at Condé Nast International, we want to discover how you handle infrastructure day-to-day.  We appreciate that your time is valuable, which is why we’ve designed this exercise to be completed in around 2 hours. If you cannot spare the time, you may want to consider option 2.
+This is a coding exercise to help us assess candidates looking to join the Infrastructure Engineering team at Condé Nast, we want to discover how you handle infrastructure day-to-day.  We appreciate that your time is valuable, which is why we’ve designed this exercise to be completed in around 2 hours. If you cannot spare the time, you may want to consider option 2.
  
 ### Things we like
 


### PR DESCRIPTION
This just removes the word `international` from readmes from now - will follow up with the team about amending `package.json` and even potentially migrating to `Condé Nast` org